### PR TITLE
♻️ 코틀린 문자열 계산기 리팩토링

### DIFF
--- a/kt-string-calculator/src/main/kotlin/io/github/shirohoo/calculator/ArithmeticOperator.kt
+++ b/kt-string-calculator/src/main/kotlin/io/github/shirohoo/calculator/ArithmeticOperator.kt
@@ -1,0 +1,30 @@
+package io.github.shirohoo.calculator
+
+import java.util.function.DoubleBinaryOperator
+
+enum class ArithmeticOperator(private val operator: Char, private val f: DoubleBinaryOperator) {
+    PLUS('+', DoubleBinaryOperator { left: Double, right: Double -> left + right }),
+    MINUS('-', DoubleBinaryOperator { left: Double, right: Double -> left - right }),
+    MULTIPLY('*', DoubleBinaryOperator { left: Double, right: Double -> left * right }),
+    DIVIDE('/', DoubleBinaryOperator { left: Double, right: Double -> left / right });
+
+    fun apply(left: Double, right: Double): Double {
+        if (isZeroDivide(right)) {
+            throw ArithmeticException("0으로는 나눌 수 없습니다")
+        }
+        return f.applyAsDouble(left, right)
+    }
+
+    private fun isZeroDivide(right: Double): Boolean {
+        return this == DIVIDE && right == 0.0
+    }
+
+    companion object {
+        fun findByOperator(operator: Char): ArithmeticOperator {
+            return values()
+                .asSequence()
+                .filter { it.operator == operator }
+                .first()
+        }
+    }
+}

--- a/kt-string-calculator/src/main/kotlin/io/github/shirohoo/calculator/SequentialCalculator.kt
+++ b/kt-string-calculator/src/main/kotlin/io/github/shirohoo/calculator/SequentialCalculator.kt
@@ -1,7 +1,6 @@
 package io.github.shirohoo.calculator
 
 import java.util.*
-import java.util.function.DoubleBinaryOperator
 
 class SequentialCalculator : Calculator {
     override fun calculate(expr: Expression): Double {
@@ -32,32 +31,5 @@ class SequentialCalculator : Calculator {
             .filter(String::isNotEmpty)
             .map(String::toDouble)
             .toCollection(LinkedList())
-    }
-
-    private enum class ArithmeticOperator(private val operator: Char, private val f: DoubleBinaryOperator) {
-        PLUS('+', DoubleBinaryOperator { left: Double, right: Double -> left + right }),
-        MINUS('-', DoubleBinaryOperator { left: Double, right: Double -> left - right }),
-        MULTIPLY('*', DoubleBinaryOperator { left: Double, right: Double -> left * right }),
-        DIVIDE('/', DoubleBinaryOperator { left: Double, right: Double -> left / right });
-
-        fun apply(left: Double, right: Double): Double {
-            if (isZeroDivide(right)) {
-                throw ArithmeticException("0으로는 나눌 수 없습니다")
-            }
-            return f.applyAsDouble(left, right)
-        }
-
-        private fun isZeroDivide(right: Double): Boolean {
-            return this == DIVIDE && right == 0.0
-        }
-
-        companion object {
-            fun findByOperator(operator: Char): ArithmeticOperator {
-                return values()
-                    .asSequence()
-                    .filter { it.operator == operator }
-                    .first()
-            }
-        }
     }
 }

--- a/kt-string-calculator/src/test/kotlin/io/github/shirohoo/calculator/ArithmeticOperatorTests.kt
+++ b/kt-string-calculator/src/test/kotlin/io/github/shirohoo/calculator/ArithmeticOperatorTests.kt
@@ -1,0 +1,46 @@
+package io.github.shirohoo.calculator
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+class ArithmeticOperatorTests {
+    @MethodSource
+    @ParameterizedTest
+    fun findByOperator(operator: Char, expected: ArithmeticOperator?) {
+        assertEquals(expected, ArithmeticOperator.findByOperator(operator))
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "+:5:2:7",
+            "-:5:2:3",
+            "*:5:2:10",
+            "/:5:2:2.5"
+        ],
+        delimiter = ':'
+    )
+    fun apply(operator: Char, left: Double, right: Double, expected: Double) {
+        val sut: ArithmeticOperator = ArithmeticOperator.findByOperator(operator)
+
+        val actual: Double = sut.apply(left, right)
+
+        assertEquals(expected, actual)
+    }
+
+    companion object {
+        @JvmStatic
+        fun findByOperator(): Stream<Arguments?>? {
+            return Stream.of(
+                Arguments.of('+', ArithmeticOperator.PLUS),
+                Arguments.of('-', ArithmeticOperator.MINUS),
+                Arguments.of('*', ArithmeticOperator.MULTIPLY),
+                Arguments.of('/', ArithmeticOperator.DIVIDE)
+            )
+        }
+    }
+}


### PR DESCRIPTION
- `산술연산자(ArithmeticOperator)`는 재사용 가능성이 높으므로, 내부 클래스가 아닌 별도의 탑 클래스로 분리하는게 좋겠다고 판단