### PR TITLE
:recycle: 자바 - 문자열계산기

### DIFF
--- a/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringCalculator.java
+++ b/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringCalculator.java
@@ -1,20 +1,11 @@
 package io.github.shirohoo.stringcalculator;
 
 import java.util.ArrayDeque;
-import java.util.Queue;
-import java.util.function.BinaryOperator;
 
 @SuppressWarnings("all") // there will never be a problem
 public final class StringCalculator {
     public double calculate(StringExpression expr) {
-        return calculate(expr.splitExpression());
-//
-//        Queue<Double> operands = expr.getOperands();
-//        Queue<Character> operators = expr.getOperators();
-//
-//        return operands.stream()
-//                .reduce(accumulate(operators))
-//                .orElseThrow();
+        return calculate(expr.split());
     }
 
     private double calculate(ArrayDeque<String> queue) {
@@ -30,13 +21,5 @@ public final class StringCalculator {
         queue.addFirst(String.valueOf(result));
 
         return calculate(queue);
-    }
-
-    private BinaryOperator<Double> accumulate(Queue<Character> operators) {
-        return (first, last) -> {
-            Character operator = operators.poll();
-            ArithmeticOperator arithmeticOperator = ArithmeticOperator.findByOperator(operator);
-            return arithmeticOperator.apply(first, last);
-        };
     }
 }

--- a/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringCalculator.java
+++ b/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringCalculator.java
@@ -1,10 +1,12 @@
 package io.github.shirohoo.stringcalculator;
 
 import java.util.ArrayDeque;
+import java.util.Objects;
 
 @SuppressWarnings("all") // there will never be a problem
 public final class StringCalculator {
     public double calculate(StringExpression expr) {
+        Objects.requireNonNull(expr);
         return calculate(expr.split());
     }
 

--- a/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringCalculator.java
+++ b/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringCalculator.java
@@ -1,17 +1,35 @@
 package io.github.shirohoo.stringcalculator;
 
+import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.function.BinaryOperator;
 
 @SuppressWarnings("all") // there will never be a problem
 public final class StringCalculator {
     public double calculate(StringExpression expr) {
-        Queue<Double> operands = expr.getOperands();
-        Queue<Character> operators = expr.getOperators();
+        return calculate(expr.splitExpression());
+//
+//        Queue<Double> operands = expr.getOperands();
+//        Queue<Character> operators = expr.getOperators();
+//
+//        return operands.stream()
+//                .reduce(accumulate(operators))
+//                .orElseThrow();
+    }
 
-        return operands.stream()
-                .reduce(accumulate(operators))
-                .orElseThrow();
+    private double calculate(ArrayDeque<String> queue) {
+        if (queue.size() == 1) {
+            return Double.parseDouble(queue.removeFirst());
+        }
+
+        double left = Double.parseDouble(queue.removeFirst());
+        ArithmeticOperator operator = ArithmeticOperator.findByOperator(queue.removeFirst().charAt(0));
+        double right = Double.parseDouble(queue.removeFirst());
+        double result = operator.apply(left, right);
+
+        queue.addFirst(String.valueOf(result));
+
+        return calculate(queue);
     }
 
     private BinaryOperator<Double> accumulate(Queue<Character> operators) {

--- a/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringExpression.java
+++ b/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringExpression.java
@@ -1,25 +1,19 @@
 package io.github.shirohoo.stringcalculator;
 
 import java.util.ArrayDeque;
-import java.util.LinkedList;
-import java.util.Queue;
-import java.util.regex.Pattern;
 
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toCollection;
 
 public final class StringExpression {
-    private static final Pattern pattern = Pattern.compile("^\\d+(:? ?[+\\-*/] ?\\d+)*$");
-
     private final String expr;
 
     public StringExpression(String expr) {
-        if (expr == null || !pattern.matcher(expr).matches()) {
+        if (expr == null || !expr.matches("^\\d+(:? ?[+\\-*/] ?\\d+)*$")) {
             throw new IllegalArgumentException("Please enter the correct expression.");
         }
 
         expr = expr.replace(" ", "");
-
         if (expr.contains("/0")) {
             throw new IllegalArgumentException("You can't divide by zero because it causes an infinite loop.");
         }
@@ -27,25 +21,7 @@ public final class StringExpression {
         this.expr = expr;
     }
 
-    public Queue<Character> getOperators() {
-        String[] split = expr.replaceAll("\\d", "").split("");
-
-        if (split.length == 0 || split.length == 1) {
-            return new LinkedList<>();
-        }
-
-        return stream(split)
-                .map(operator -> operator.charAt(0))
-                .collect(toCollection(LinkedList::new));
-    }
-
-    public Queue<Double> getOperands() {
-        return stream(expr.split("\\D"))
-                .map(Double::parseDouble)
-                .collect(toCollection(LinkedList::new));
-    }
-
-    public ArrayDeque<String> splitExpression() {
+    public ArrayDeque<String> split() {
         return stream(expr.replaceAll("(\\d)([+\\-*/])", "$1 $2 ")
                 .split(" "))
                 .collect(toCollection(ArrayDeque::new));

--- a/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringExpression.java
+++ b/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringExpression.java
@@ -43,4 +43,8 @@ public final class StringExpression {
                 .map(Double::parseDouble)
                 .collect(toCollection(LinkedList::new));
     }
+
+    public Queue<String> splitExpression() {
+        return null;
+    }
 }

--- a/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringExpression.java
+++ b/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringExpression.java
@@ -45,6 +45,8 @@ public final class StringExpression {
     }
 
     public Queue<String> splitExpression() {
-        return null;
+        return stream(expr.replaceAll("(\\d)([+\\-*/])", "$1 $2 ")
+                .split(" "))
+                .collect(toCollection(LinkedList::new));
     }
 }

--- a/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringExpression.java
+++ b/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringExpression.java
@@ -1,5 +1,6 @@
 package io.github.shirohoo.stringcalculator;
 
+import java.util.ArrayDeque;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.regex.Pattern;
@@ -44,9 +45,9 @@ public final class StringExpression {
                 .collect(toCollection(LinkedList::new));
     }
 
-    public Queue<String> splitExpression() {
+    public ArrayDeque<String> splitExpression() {
         return stream(expr.replaceAll("(\\d)([+\\-*/])", "$1 $2 ")
                 .split(" "))
-                .collect(toCollection(LinkedList::new));
+                .collect(toCollection(ArrayDeque::new));
     }
 }

--- a/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringExpression.java
+++ b/java-string-calculator/src/main/java/io/github/shirohoo/stringcalculator/StringExpression.java
@@ -1,21 +1,29 @@
 package io.github.shirohoo.stringcalculator;
 
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.toCollection;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.regex.Pattern;
 
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toCollection;
+
 public final class StringExpression {
-    private static final Pattern PATTERN = Pattern.compile("^\\d+(:? ?[+\\-*/] ?\\d+)*$");
+    private static final Pattern pattern = Pattern.compile("^\\d+(:? ?[+\\-*/] ?\\d+)*$");
 
     private final String expr;
 
     public StringExpression(String expr) {
-        if (expr == null || !PATTERN.matcher(expr).matches()) {
+        if (expr == null || !pattern.matcher(expr).matches()) {
             throw new IllegalArgumentException("Please enter the correct expression.");
         }
-        this.expr = expr.replace(" ", "");
+
+        expr = expr.replace(" ", "");
+
+        if (expr.contains("/0")) {
+            throw new IllegalArgumentException("You can't divide by zero because it causes an infinite loop.");
+        }
+
+        this.expr = expr;
     }
 
     public Queue<Character> getOperators() {

--- a/java-string-calculator/src/test/java/io/github/shirohoo/stringcalculator/ArithmeticOperatorTests.java
+++ b/java-string-calculator/src/test/java/io/github/shirohoo/stringcalculator/ArithmeticOperatorTests.java
@@ -1,11 +1,15 @@
 package io.github.shirohoo.stringcalculator;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ArithmeticOperatorTests {
     @MethodSource
@@ -22,6 +26,14 @@ class ArithmeticOperatorTests {
                 Arguments.of('*', ArithmeticOperator.MULTIPLY),
                 Arguments.of('/', ArithmeticOperator.DIVIDE)
         );
+    }
+
+    @Test
+    void shouldThrownExceptionThatNotDivisibleByZero() {
+        ArithmeticOperator divide = ArithmeticOperator.DIVIDE;
+        assertThatThrownBy(() -> divide.apply(1, 0))
+                .isInstanceOf(ArithmeticException.class)
+                .hasMessage("not divisible by zero");
     }
 
     @ParameterizedTest

--- a/java-string-calculator/src/test/java/io/github/shirohoo/stringcalculator/StringExpressionTests.java
+++ b/java-string-calculator/src/test/java/io/github/shirohoo/stringcalculator/StringExpressionTests.java
@@ -1,13 +1,13 @@
 package io.github.shirohoo.stringcalculator;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import java.util.Queue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Queue;
+
+import static org.assertj.core.api.Assertions.*;
 
 class StringExpressionTests {
     @ParameterizedTest
@@ -49,6 +49,18 @@ class StringExpressionTests {
         assertThatThrownBy(() -> new StringExpression(expr))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("You can't divide by zero because it causes an infinite loop.");
+    }
+
+    @Test
+    void shouldReturnQueueForSplitExpression() {
+        // given
+        StringExpression sut = new StringExpression("2 +44 -7 * 1 /5");
+
+        // when
+        Queue<String> actual = sut.splitExpression();
+
+        // then
+        assertThat(actual.size()).isEqualTo(9);
     }
 
     @Test

--- a/java-string-calculator/src/test/java/io/github/shirohoo/stringcalculator/StringExpressionTests.java
+++ b/java-string-calculator/src/test/java/io/github/shirohoo/stringcalculator/StringExpressionTests.java
@@ -39,6 +39,18 @@ class StringExpressionTests {
                 .hasMessage("Please enter the correct expression.");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "123 +1 /0",
+            "123 +1 /0 +3",
+            "123 +1 /0*2",
+    })
+    void shouldThrowExceptionThatSaysNotDivisibleByZero(String expr) {
+        assertThatThrownBy(() -> new StringExpression(expr))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("You can't divide by zero because it causes an infinite loop.");
+    }
+
     @Test
     void shouldSplitExpressionReturnOperator() {
         // given

--- a/java-string-calculator/src/test/java/io/github/shirohoo/stringcalculator/StringExpressionTests.java
+++ b/java-string-calculator/src/test/java/io/github/shirohoo/stringcalculator/StringExpressionTests.java
@@ -45,7 +45,7 @@ class StringExpressionTests {
             "123 +1 /0 +3",
             "123 +1 /0*2",
     })
-    void shouldThrowExceptionThatSaysNotDivisibleByZero(String expr) {
+    void shouldThrownExceptionThatSaysNotDivisibleByZero(String expr) {
         assertThatThrownBy(() -> new StringExpression(expr))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("You can't divide by zero because it causes an infinite loop.");

--- a/java-string-calculator/src/test/java/io/github/shirohoo/stringcalculator/StringExpressionTests.java
+++ b/java-string-calculator/src/test/java/io/github/shirohoo/stringcalculator/StringExpressionTests.java
@@ -57,33 +57,9 @@ class StringExpressionTests {
         StringExpression sut = new StringExpression("2 +44 -7 * 1 /5");
 
         // when
-        Queue<String> actual = sut.splitExpression();
+        Queue<String> actual = sut.split();
 
         // then
         assertThat(actual.size()).isEqualTo(9);
-    }
-
-    @Test
-    void shouldSplitExpressionReturnOperator() {
-        // given
-        StringExpression sut = new StringExpression("2 +44 -7 * 1 /5");
-
-        // when
-        Queue<Character> actual = sut.getOperators();
-
-        // then
-        assertThat(actual.size()).isEqualTo(4);
-    }
-
-    @Test
-    void shouldSplitExpressionReturnOperand() {
-        // given
-        StringExpression sut = new StringExpression("2 +44 -7 * 1 /5");
-
-        // when
-        Queue<Double> actual = sut.getOperands();
-
-        // then
-        assertThat(actual.size()).isEqualTo(5);
     }
 }


### PR DESCRIPTION
- 사용자 입력에 0으로 나누는 수식이 포함된 경우 `StringExpression` 클래스의 생성자에서 미리 차단하도록 변경
- `StringExpression` 클래스가 수식을 `ArrayDeque<String>`으로 반환하도록 변경
- `StringCalculator`에 `StringExpression`가 아닌 `null`이 입력되면 방어하도록 변경
- 연산을 재귀 함수로 처리하도록 변경